### PR TITLE
Byte buffer cleaner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.iml
 target
+tags

--- a/src/main/java/ca/hullabaloo/cdb/ByteBufferCleaner.java
+++ b/src/main/java/ca/hullabaloo/cdb/ByteBufferCleaner.java
@@ -1,0 +1,62 @@
+package ca.hullabaloo.cdb;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.MappedByteBuffer;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+/**
+ * This code was taken from lucene. See NOTICE file for more details.
+ */
+class ByteBufferCleaner {
+
+  /**
+   * <code>true</code>, if this platform supports unmapping mmapped files.
+   */
+  public static final boolean UNMAP_SUPPORTED;
+  static {
+    boolean v;
+    try {
+      Class.forName("sun.misc.Cleaner");
+      Class.forName("java.nio.DirectByteBuffer")
+              .getMethod("cleaner");
+      v = true;
+    } catch (Exception e) {
+      v = false;
+    }
+    UNMAP_SUPPORTED = v;
+  }
+
+  /**
+   * Try to unmap the buffer, this method silently fails if no support
+   * for that in the JVM. On Windows, this leads to the fact,
+   * that mmapped files cannot be modified or deleted.
+   */
+  public static void cleanMapping(final MappedByteBuffer buffer) {
+    if (!UNMAP_SUPPORTED) {
+      return;
+    }
+
+    try {
+      AccessController.doPrivileged(new PrivilegedExceptionAction<Object>() {
+        public Object run() throws Exception {
+          final Method getCleanerMethod = buffer.getClass()
+                  .getMethod("cleaner");
+          getCleanerMethod.setAccessible(true);
+
+          final Object cleaner = getCleanerMethod.invoke(buffer);
+          if (cleaner != null) {
+            cleaner.getClass().getMethod("clean").invoke(cleaner);
+          }
+          return null;
+        }
+      });
+    } catch (PrivilegedActionException e) {
+      final IOException ioe = new IOException("unable to unmap the mapped buffer");
+      ioe.initCause(e.getCause());
+      e.printStackTrace(System.err);
+    }
+  }
+}

--- a/src/main/java/ca/hullabaloo/cdb/Cdb.java
+++ b/src/main/java/ca/hullabaloo/cdb/Cdb.java
@@ -38,6 +38,12 @@ public class Cdb {
     return new CdbMap(new CdbFile(file));
   }
 
+  public static void close(Map<ByteBuffer, ByteBuffer> map) throws IOException {
+    if (map instanceof CdbMap) {
+      ((CdbMap)map).close();
+    }
+  }
+
   public interface Builder extends Closeable {
     public void put(ByteBuffer key, ByteBuffer value) throws IOException;
 

--- a/src/main/java/ca/hullabaloo/cdb/Cdb.java
+++ b/src/main/java/ca/hullabaloo/cdb/Cdb.java
@@ -40,7 +40,7 @@ public class Cdb {
 
   public static void close(Map<ByteBuffer, ByteBuffer> map) throws IOException {
     if (map instanceof CdbMap) {
-      ((CdbMap)map).close();
+      ((CdbMap)map).closeCdbFile();
     }
   }
 

--- a/src/main/java/ca/hullabaloo/cdb/CdbFile.java
+++ b/src/main/java/ca/hullabaloo/cdb/CdbFile.java
@@ -1,5 +1,6 @@
 package ca.hullabaloo.cdb;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -14,7 +15,7 @@ import java.nio.channels.FileChannel;
  * @see Cdb
  * @see CdbBuilder
  */
-class CdbFile {
+class CdbFile implements Closeable {
   private static final int INTEGER_BYTES = Integer.SIZE / Byte.SIZE;
   private static final int SLOT_BYTES = INTEGER_BYTES * 2;
 
@@ -150,5 +151,10 @@ class CdbFile {
     ByteBuffer bb = this.data.duplicate();
     bb.order(this.data.order());
     return bb;
+  }
+
+  public void close() {
+    // TODO: mark as closed.
+    ByteBufferCleaner.cleanMapping(this.data);
   }
 }

--- a/src/main/java/ca/hullabaloo/cdb/CdbMap.java
+++ b/src/main/java/ca/hullabaloo/cdb/CdbMap.java
@@ -91,4 +91,9 @@ class CdbMap extends AbstractMap<ByteBuffer, ByteBuffer> {
       throw new UnsupportedOperationException();
     }
   }
+
+  public void close() {
+    // TODO: mark as closed.
+    this.file.close();
+  }
 }

--- a/src/main/java/ca/hullabaloo/cdb/CdbMap.java
+++ b/src/main/java/ca/hullabaloo/cdb/CdbMap.java
@@ -92,7 +92,7 @@ class CdbMap extends AbstractMap<ByteBuffer, ByteBuffer> {
     }
   }
 
-  public void close() {
+  void closeCdbFile() {
     // TODO: mark as closed.
     this.file.close();
   }


### PR DESCRIPTION
`MappedByteBuffer` will cause file descriptor (and memory) leak, because of it depend on GC timing.
So we might clean it explicitly

Most codes in this PR comes from [sparkey-java](https://github.com/spotify/sparkey-java) and Lucene 3.6, please check [details](https://github.com/spotify/sparkey-java/pull/13).
